### PR TITLE
Remove reference to unavailable pip command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ The package is still in beta, but the following features are available:
 pip install pysmartthings
 ```
 
-or
-
-```commandline
-pip install --use-wheel pysmartthings
-```
-
 ## Usage
 
 ### Initialization


### PR DESCRIPTION
## Description:

`--use-wheel` was deprecated in 2015, and [removed in 2018](https://pip.pypa.io/en/stable/news/#id934).  Its replacement `--use-binary :all:` does not appear to work, perhaps because a dependency is not available in a binary package.  Save people some time by not suggesting to use it.

**Related issue (if applicable):** fixes #<pysmartthings issue number goes here>

## Checklist:

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
- [x] `README.MD` updated (if necessary)
