### PR TITLE
Make sure we only log a missing capability once

### DIFF
--- a/src/pysmartthings/models.py
+++ b/src/pysmartthings/models.py
@@ -14,6 +14,8 @@ from .attribute import Attribute  # noqa: TC001
 from .capability import Capability
 from .const import LOGGER
 
+ALREADY_LOGGED_CAPABILITIES = set()
+
 
 @dataclass
 class BaseLocation(DataClassORJSONMixin):
@@ -351,7 +353,11 @@ class DeviceStatus(DataClassORJSONMixin):
         """Make sure we let the user know about unknown capabilities."""
         for component in obj.components.values():
             for capability in component:
-                if capability not in Capability:
+                if (
+                    capability not in Capability
+                    and capability not in ALREADY_LOGGED_CAPABILITIES
+                ):
+                    ALREADY_LOGGED_CAPABILITIES.add(capability)
                     LOGGER.warning(
                         "Unknown capability %s. Please raise an issue at https://github.com/pySmartThings/pysmartthings.",
                         capability,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -305,6 +305,17 @@ async def test_fetching_unknown_capability(
         "Unknown capability fakeCapability. Please raise an issue at https://github.com/pySmartThings/pysmartthings."
         in caplog.text
     )
+    caplog.clear()
+    responses.get(
+        f"{MOCK_URL}/v1/devices/440063de-a200-40b5-8a6b-f3399eaa0370/status",
+        status=200,
+        body=load_fixture("device_status/fake.json"),
+    )
+    await client.get_device_status("440063de-a200-40b5-8a6b-f3399eaa0370")
+    assert (
+        "Unknown capability fakeCapability. Please raise an issue at https://github.com/pySmartThings/pysmartthings."
+        not in caplog.text
+    )
 
 
 async def test_fetching_unknown_category(


### PR DESCRIPTION
Make sure we only log a missing capability once.

While we do like the extra data, when you have a lot of the same device it can become confusing to which ones are missing, so let's only log them once