### PR TITLE
Add samsungce.sleepDataInteroperation capability

### DIFF
--- a/src/pysmartthings/attribute.py
+++ b/src/pysmartthings/attribute.py
@@ -172,6 +172,7 @@ class Attribute(StrEnum):
     CONDITION = "condition"
     CONNECTED_DEVICE_COUNT = "connectedDeviceCount"
     CONNECTED_DEVICE_ID = "connectedDeviceId"
+    CONNECTED_DEVICES = "connectedDevices"
     CONNECTED_ROUTER_COUNT = "connectedRouterCount"
     CONNECTED_USER_ID = "connectedUserId"
     CONNECTION = "connection"
@@ -596,6 +597,7 @@ class Attribute(StrEnum):
     MAX_CODE_LENGTH = "maxCodeLength"
     MAX_CODES = "maxCodes"
     MAX_CURRENT = "maxCurrent"
+    MAX_DEVICES = "maxDevices"
     MAX_NUMBER_OF_PRESETS = "maxNumberOfPresets"
     MAX_NUMBER_OF_RECIPES = "maxNumberOfRecipes"
     MAX_NUMBER_OF_RESERVATIONS = "maxNumberOfReservations"
@@ -903,6 +905,8 @@ class Attribute(StrEnum):
     SIREN_OR_BELL_ACTIVE = "sirenOrBellActive"
     SIREN_SOUNDS = "sirenSounds"
     SLEEPING = "sleeping"
+    SLEEP_DATA = "sleepData"
+    SLEEP_STATUS = "sleepStatus"
     SLOT_STATE = "slotState"
     SMART_KEY_BATTERY = "smartKeyBattery"
     SMOKE = "smoke"
@@ -2954,6 +2958,13 @@ CAPABILITY_ATTRIBUTES: dict[Capability, list[Attribute]] = {
     ],
     Capability.SAMSUNG_CE_SENSING_ON_SUSPEND_MODE: [Attribute.SENSING_ON_SUSPEND_MODE],
     Capability.SAMSUNG_CE_SILENT_ACTION: [],
+    Capability.SAMSUNG_CE_SLEEP_DATA_INTEROPERATION: [
+        Attribute.CONNECTED_DEVICES,
+        Attribute.ENABLED,
+        Attribute.MAX_DEVICES,
+        Attribute.SLEEP_DATA,
+        Attribute.SLEEP_STATUS,
+    ],
     Capability.SAMSUNG_CE_SOFTENER_AUTO_REPLENISHMENT: [
         Attribute.REGULAR_SOFTENER_ALARM_ENABLED,
         Attribute.REGULAR_SOFTENER_DOSAGE,

--- a/src/pysmartthings/capability.py
+++ b/src/pysmartthings/capability.py
@@ -521,6 +521,7 @@ class Capability(StrEnum):
     SAMSUNG_CE_SELF_CHECK = "samsungce.selfCheck"
     SAMSUNG_CE_SENSING_ON_SUSPEND_MODE = "samsungce.sensingOnSuspendMode"
     SAMSUNG_CE_SILENT_ACTION = "samsungce.silentAction"
+    SAMSUNG_CE_SLEEP_DATA_INTEROPERATION = "samsungce.sleepDataInteroperation"
     SAMSUNG_CE_SOFTENER_AUTO_REPLENISHMENT = "samsungce.softenerAutoReplenishment"
     SAMSUNG_CE_SOFTENER_ORDER = "samsungce.softenerOrder"
     SAMSUNG_CE_SOFTENER_STATE = "samsungce.softenerState"

--- a/src/pysmartthings/command.py
+++ b/src/pysmartthings/command.py
@@ -266,6 +266,7 @@ class Command(StrEnum):
     SET_COLOR_TEMPERATURE = "setColorTemperature"
     SET_COLOR_VALUE = "setColorValue"
     SET_COMPLETION_TIME = "setCompletionTime"
+    SET_CONNECTED_DEVICES = "setConnectedDevices"
     SET_CONDITION = "setCondition"
     SET_CONTENT_TEXT = "setContentText"
     SET_CONTENT_TITLE = "setContentTitle"
@@ -530,6 +531,8 @@ class Command(StrEnum):
     SET_SIGNAL_METRICS = "setSignalMetrics"
     SET_SIREN_OR_BELL_ACTIVE = "setSirenOrBellActive"
     SET_SIREN_SOUNDS = "setSirenSounds"
+    SET_SLEEP_DATA = "setSleepData"
+    SET_SLEEP_STATUS = "setSleepStatus"
     SET_SOFTENER_TYPE = "setSoftenerType"
     SET_SOUND_FROM = "setSoundFrom"
     SET_SOUND_MODE = "setSoundMode"
@@ -1641,6 +1644,13 @@ CAPABILITY_COMMANDS: dict[Capability, list[Command]] = {
     ],
     Capability.SAMSUNG_CE_SENSING_ON_SUSPEND_MODE: [],
     Capability.SAMSUNG_CE_SILENT_ACTION: [Command.ACT_SILENTLY],
+    Capability.SAMSUNG_CE_SLEEP_DATA_INTEROPERATION: [
+        Command.DISABLE,
+        Command.ENABLE,
+        Command.SET_CONNECTED_DEVICES,
+        Command.SET_SLEEP_DATA,
+        Command.SET_SLEEP_STATUS,
+    ],
     Capability.SAMSUNG_CE_SOFTENER_AUTO_REPLENISHMENT: [
         Command.DISABLE_ALARM,
         Command.ENABLE_ALARM,


### PR DESCRIPTION
## Description:

Adds support for samsungce.sleepDataInteroperation.

This capability is exposed by Samsung OCF Air Conditioner devices and is currently reported as unknown by pysmartthings/Home Assistant.

Adds the capability, its attributes, commands, and the corresponding capability mappings.

curl -s -H "Authorization: Bearer ${Token}" "https://api.smartthings.com/v1/capabilities/samsungce.sleepDataInteroperation/1" 
{"id":"samsungce.sleepDataInteroperation","version":1,"status":"proposed","name":"Sleep Data Interoperation","ephemeral":false,"attributes":{"sleepStatus":{"schema":{"type":"object","properties":{"value":{"type":"string","enum":["sleepOnset","awake"]}},"additionalProperties":false,"required":["value"]},"enumCommands":[]},"sleepData":{"schema":{"type":"object","properties":{"value":{"type":"object","additionalProperties":false,"properties":{"deviceId":{"type":"string"},"sequenceNumber":{"type":"integer","minimum":0,"maximum":99},"sleepStages":{"type":"string"},"start":{"type":"string","pattern":"^(?:[1-9]\\d{3}-?(?:(?:0[1-9]|1[0-2])-?(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-?(?:29|30)|(?:0[13578]|1[02])-?31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-?02-?29)T(?:[01]\\d|2[0-3]):?[0-5]\\d:?[0-5]\\d(?:\\.\\d{3})?(?:Z|[+-][01]\\d(?::?[0-5]\\d)?)$"},"end":{"type":"string","pattern":"^(?:[1-9]\\d{3}-?(?:(?:0[1-9]|1[0-2])-?(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-?(?:29|30)|(?:0[13578]|1[02])-?31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-?02-?29)T(?:[01]\\d|2[0-3]):?[0-5]\\d:?[0-5]\\d(?:\\.\\d{3})?(?:Z|[+-][01]\\d(?::?[0-5]\\d)?)$"}}}},"additionalProperties":false,"required":["value"]},"enumCommands":[]},"maxDevices":{"schema":{"type":"object","properties":{"value":{"type":"integer","minimum":1}},"additionalProperties":false,"required":["value"]},"enumCommands":[]},"connectedDevices":{"schema":{"type":"object","properties":{"value":{"type":"array","items":{"type":"string"}}},"additionalProperties":false,"required":["value"]},"enumCommands":[]},"enabled":{"schema":{"type":"object","properties":{"value":{"type":"boolean"}},"additionalProperties":false,"required":["value"]},"enumCommands":[]}},"commands":{"setSleepStatus":{"name":"setSleepStatus","arguments":[{"name":"sleepStatus","optional":false,"schema":{"type":"string","enum":["sleepOnset","awake"]}}],"sensitive":false},"enable":{"name":"enable","arguments":[],"sensitive":false},"disable":{"name":"disable","arguments":[],"sensitive":false},"setSleepData":{"name":"setSleepData","arguments":[{"name":"sleepData","optional":false,"schema":{"type":"object","additionalProperties":false,"properties":{"deviceId":{"type":"string"},"sequenceNumber":{"type":"integer","minimum":0,"maximum":99},"sleepStages":{"type":"string"},"start":{"type":"string","pattern":"^(?:[1-9]\\d{3}-?(?:(?:0[1-9]|1[0-2])-?(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-?(?:29|30)|(?:0[13578]|1[02])-?31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-?02-?29)T(?:[01]\\d|2[0-3]):?[0-5]\\d:?[0-5]\\d(?:\\.\\d{3})?(?:Z|[+-][01]\\d(?::?[0-5]\\d)?)$"},"end":{"type":"string","pattern":"^(?:[1-9]\\d{3}-?(?:(?:0[1-9]|1[0-2])-?(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-?(?:29|30)|(?:0[13578]|1[02])-?31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-?02-?29)T(?:[01]\\d|2[0-3]):?[0-5]\\d:?[0-5]\\d(?:\\.\\d{3})?(?:Z|[+-][01]\\d(?::?[0-5]\\d)?)$"}}}}],"sensitive":false},"setConnectedDevices":{"name":"setConnectedDevices","arguments":[{"name":"connectedDevices","optional":false,"schema":{"type":"array","items":{"type":"string"}}}],"sensitive":false}}} 

**Related issue (if applicable):** fixes #661

## Checklist:

- [ ] The code change is tested and works locally.
- [ ] Local tests pass.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
- [ ] `README.MD` updated (if necessary)


## Type of change:
- [ ] breaking-change
- [ ] bugfix
- [ ] documentation
- [X] enhancement
- [ ] refactor
- [ ] performance
- [ ] new-feature
- [ ] maintenance
- [ ] ci
- [ ] dependencies
