### PR TITLE
Add device presentation endpoint

### DIFF
--- a/src/pysmartthings/smartthings.py
+++ b/src/pysmartthings/smartthings.py
@@ -299,6 +299,13 @@ class SmartThings:
         """Retrieve a device with the specified ID."""
         return cast("dict[str, Any]", orjson.loads(await self._get_device(device_id)))  # pylint: disable=no-member
 
+    async def get_device_presentation(self, device_id: str) -> dict[str, Any]:
+        """Retrieve the presentation for a device."""
+        resp = await self._get(
+            "v1/devices/presentation", params={"deviceId": device_id}
+        )
+        return cast("dict[str, Any]", orjson.loads(resp))  # pylint: disable=no-member
+
     async def get_scenes(self, location_id: str | None = None) -> list[Scene]:
         """Retrieve SmartThings scenes."""
         params = {}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -121,6 +121,29 @@ async def test_fetching_single_device(
     )
 
 
+async def test_fetching_device_presentation(
+    client: SmartThings,
+    responses: aioresponses,
+) -> None:
+    """Test getting a device presentation."""
+    device_id = "440063de-a200-40b5-8a6b-f3399eaa0370"
+    presentation = {"presentationId": "generic-fan-5-speed"}
+    responses.get(
+        str(URL(f"{MOCK_URL}/v1/devices/presentation").with_query(deviceId=device_id)),
+        status=200,
+        payload=presentation,
+    )
+
+    assert await client.get_device_presentation(device_id) == presentation
+    responses.assert_called_once_with(
+        f"{MOCK_URL}/v1/devices/presentation",
+        METH_GET,
+        headers=HEADERS,
+        params={"deviceId": device_id},
+        json=None,
+    )
+
+
 @pytest.mark.parametrize(
     "fixture",
     [


### PR DESCRIPTION
## Description:

Add `get_device_presentation()` to retrieve the resolved SmartThings presentation for a device through the official `/v1/devices/presentation` endpoint.

Device presentations contain per-device capability metadata such as supported ranges and steps. Exposing this endpoint allows consumers to honor the actual device configuration instead of relying on global capability defaults.

The new request path and query parameter are covered by a focused test.

**Related issue (if applicable):** N/A

## Checklist:

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
- [ ] `README.MD` updated (if necessary)
