### PR TITLE
test: minor readability cleanups from ShipGate auto-fix pass

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,10 @@ from collections.abc import AsyncGenerator, Generator
 
 from aiohttp import ClientSession
 from aioresponses import aioresponses
-
-from pysmartthings import SmartThings
 import pytest
 from syrupy import SnapshotAssertion
+
+from pysmartthings import SmartThings
 
 from .syrupy import SmartThingsSnapshotExtension
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-import pytest
 from aiohttp.hdrs import METH_GET, METH_POST
 from aioresponses import aioresponses
+import pytest
 from yarl import URL
 
-from pysmartthings import SmartThings, Capability, Command, SmartThingsCommandError
-from . import load_fixture, load_json_fixture
+from pysmartthings import Capability, Command, SmartThings, SmartThingsCommandError
 
-from .const import MOCK_URL, HEADERS
+from . import load_fixture, load_json_fixture
+from .const import HEADERS, MOCK_URL
 
 if TYPE_CHECKING:
     from syrupy import SnapshotAssertion

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -5,9 +5,9 @@ from aioresponses import aioresponses
 from syrupy import SnapshotAssertion
 
 from pysmartthings import SmartThings
-from . import load_fixture
 
-from .const import MOCK_URL, HEADERS
+from . import load_fixture
+from .const import HEADERS, MOCK_URL
 
 
 async def test_fetching_all_locations(

--- a/tests/test_room.py
+++ b/tests/test_room.py
@@ -7,7 +7,7 @@ from syrupy import SnapshotAssertion
 from pysmartthings import SmartThings
 
 from . import load_fixture
-from .const import MOCK_URL, HEADERS
+from .const import HEADERS, MOCK_URL
 
 
 async def test_fetching_all_rooms(

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -6,7 +6,7 @@ from syrupy import SnapshotAssertion
 
 from pysmartthings import SmartThings
 from tests import load_fixture
-from tests.const import MOCK_URL, HEADERS
+from tests.const import HEADERS, MOCK_URL
 
 
 async def test_fetching_all_scenes(

--- a/tests/test_smartapp.py
+++ b/tests/test_smartapp.py
@@ -5,9 +5,9 @@ from aioresponses import aioresponses
 from syrupy import SnapshotAssertion
 
 from pysmartthings import SmartThings
-from . import load_fixture
 
-from .const import MOCK_URL, HEADERS
+from . import load_fixture
+from .const import HEADERS, MOCK_URL
 
 
 async def test_deleting_smart_app(


### PR DESCRIPTION
Minor test readability cleanups from a ShipGate auto-fix pass on the `tests/` tree (production modules unchanged).

## Summary

*Review run with ShipGate 0.1.7.*

ShipGate reported **~110 lint findings** and **~40 format items** in the full check suite. This PR applies small test-only style fixes; see the linked gist for raw captures.

Hotspots and improvement notes below are scoped to **Python (`*.py`)** source.
### File hotspots

| File | Issues | Action |
| --- | ---: | --- |
| `tests/test_device.py` | ~10 lint | simplify assertions and imports in device tests |
| `tests/conftest.py` | ~4 lint | align fixtures with project typing |
| `tests/test_smartapp.py` | ~4 lint | tidy smartapp test helpers |
| `tests/test_location.py` | ~4 lint | minor assertion style |
| `tests/test_room.py` | ~2 lint | minor assertion style |
| `tests/test_scenes.py` | ~2 lint | minor assertion style |
### Refactor hints (optional apply)

*No hint-tier refactor opportunities in scope (or `refactor-strict.out` empty).*
## What you are doing right

- **Security:** No high-severity bandit hits in the scanned scope.
- **Structure:** Core `src/pysmartthings` modules are compact and well-factored.

## What you could improve

- **Duplication (~34.8% in scan):** jscpd flags duplicate blocks — review test fixtures and API wrappers.
- **Lint / style (~110 findings):** Many are test-only; align with existing ruff config.

## Changes

| Pass | Files | Fixes / rules | Manual? |
| --- | ---: | --- | --- |
| `shipgate format` + `ruff --fix` | 6 | test readability / import style only | no |
| **Total** | **6** | ~13 insertions / ~13 deletions | — |
